### PR TITLE
Support no databases

### DIFF
--- a/src/apps/AppInstance.ts
+++ b/src/apps/AppInstance.ts
@@ -10,7 +10,7 @@ import {
 
 export interface RegionalInstance {
   readonly registry: AppRegistryStackProps;
-  readonly documentDatabase: AppDocumentDatabaseStackProps;
+  readonly documentDatabase?: AppDocumentDatabaseStackProps;
   readonly cluster: AppClusterStackProps;
 }
 
@@ -27,17 +27,19 @@ export class AppInstance extends cdk.App {
   constructor(props: AppInstanceProps) {
     super(props);
 
-    const documentDatabaseStack = new AppDocumentDatabaseStack(
-      this,
-      `${props.name}-AppDocumentDatabase-global`,
-      {
-        env: {
-          account: props.account,
-          region: props.primaryRegion,
-        },
-        ...props.defaults.documentDatabase,
-      }
-    );
+    const documentDatabaseStack = props.defaults.documentDatabase
+      ? new AppDocumentDatabaseStack(
+          this,
+          `${props.name}-AppDocumentDatabase-global`,
+          {
+            env: {
+              account: props.account,
+              region: props.primaryRegion,
+            },
+            ...props.defaults.documentDatabase,
+          }
+        )
+      : undefined;
 
     props.regions.forEach((region) => {
       new AppRegistryStack(this, `${props.name}-AppRegistry-${region}`, {
@@ -54,7 +56,7 @@ export class AppInstance extends cdk.App {
           account: props.account,
           region,
         },
-        documentDatabaseSecret: documentDatabaseStack.secret,
+        documentDatabaseSecret: documentDatabaseStack?.secret,
         ...props.defaults.cluster,
         ...props.regional?.[region]?.cluster,
       });

--- a/src/constructs/AppService.ts
+++ b/src/constructs/AppService.ts
@@ -81,6 +81,8 @@ export class AppService extends Construct {
       serviceName: props.serviceName,
       taskDefinition,
       minHealthyPercent: 100, // See https://github.com/aws/aws-cdk/issues/31705
+      propagateTags: ecs.PropagatedTagSource.TASK_DEFINITION,
+      enableECSManagedTags: true,
     });
   }
 


### PR DESCRIPTION
Make the document database optional so that it can work with different backend data stores

Changes:
- Document database is optional
- Propagate tags from task definitions to ECS tasks