### PR TITLE
Ditch registry stack

### DIFF
--- a/src/apps/AppInstance.ts
+++ b/src/apps/AppInstance.ts
@@ -1,7 +1,5 @@
 import * as cdk from "aws-cdk-lib";
 import {
-  AppRegistryStack,
-  AppRegistryStackProps,
   AppClusterStack,
   AppClusterStackProps,
   AppDocumentDatabaseStackProps,
@@ -9,7 +7,6 @@ import {
 } from "../stacks";
 
 export interface RegionalInstance {
-  readonly registry: AppRegistryStackProps;
   readonly documentDatabase?: AppDocumentDatabaseStackProps;
   readonly cluster: AppClusterStackProps;
 }
@@ -42,15 +39,6 @@ export class AppInstance extends cdk.App {
       : undefined;
 
     props.regions.forEach((region) => {
-      new AppRegistryStack(this, `${props.name}-AppRegistry-${region}`, {
-        env: {
-          account: props.account,
-          region,
-        },
-        ...props.defaults.registry,
-        ...props.regional?.[region]?.registry,
-      });
-
       new AppClusterStack(this, `${props.name}-AppCluster-${region}`, {
         env: {
           account: props.account,

--- a/src/apps/__tests__/AppInstance.test.ts
+++ b/src/apps/__tests__/AppInstance.test.ts
@@ -8,9 +8,6 @@ describe("AppInstance", () => {
     regions: ["us-east-1", "us-west-2"],
     primaryRegion: "us-east-1",
     defaults: {
-      registry: {
-        imageNames: ["my-image-1", "my-image-2"],
-      },
       documentDatabase: {
         vpc: {
           vpcName: "MyVpcName",
@@ -56,11 +53,6 @@ describe("AppInstance", () => {
     assembly.stacks.forEach((stack) => {
       expect(stack.stackName).toMatch(/^MyInstance-.*/);
     });
-  });
-
-  it("should create registry stacks in each region", () => {
-    expect(stackNames).toContain("MyInstance-AppRegistry-us-east-1");
-    expect(stackNames).toContain("MyInstance-AppRegistry-us-west-2");
   });
 
   it("should create cluster stacks in each region", () => {

--- a/src/constructs/AppService.ts
+++ b/src/constructs/AppService.ts
@@ -8,7 +8,7 @@ import * as iam from "aws-cdk-lib/aws-iam";
 
 export interface AppImageDefinition {
   readonly imageName: string;
-  readonly imageTag: string;
+  readonly imageTag?: string;
 }
 
 export interface AppServiceTarget {

--- a/src/constructs/AppService.ts
+++ b/src/constructs/AppService.ts
@@ -84,6 +84,14 @@ export class AppService extends Construct {
       ),
     });
 
+    // Support for ECR pull-through cache
+    taskDefinition.addToExecutionRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["ecr:CreateRepository", "ecr:BatchImportUpstreamImage"],
+        resources: [image.repositoryArn],
+      })
+    );
+
     this.fargateService = new ecs.FargateService(this, "Service", {
       cluster: props.cluster,
       serviceName: props.serviceName,


### PR DESCRIPTION
Remove ECR repositories from the scope.  Users can either create the repos manually, use replication rules, or pull through cache.

- Remove registry stack (ECR repository management)
- Makes image tag optional
- Adds pull through cache permissions to task execution roles